### PR TITLE
Address FIXME for org-return

### DIFF
--- a/config.org
+++ b/config.org
@@ -6356,8 +6356,7 @@ appropriate.  In tables, insert a new row or end the table."
                  (forward-line)
                  (insert "\n")
                  (forward-line -1))
-               ;; FIXME: looking-back is supposed to be called with more arguments.
-               (while (not (looking-back (rx (repeat 3 (seq (optional blank) "\n")))))
+               (while (not (looking-back (rx (repeat 3 (seq (optional blank) "\n"))) nil))
                  (insert "\n"))
                (forward-line -1)))))
 


### PR DESCRIPTION
I fixed this for myself, and have "borrowed" enough config from you that I thought I should return some


guessing this used to use `org-looking-back`(deprecated in org 9.0) which had the limit parameter as optional. Since no limit is intended, just pass nil

evidence from docs

``` text
Signature
(looking-back REGEXP LIMIT &optional GREEDY)

Documentation
Return non-nil if text before point matches regular expression REGEXP.

Like looking-at except matches before point, and is slower.
LIMIT if non-nil speeds up the search by specifying a minimum
starting position, to avoid checking matches that would start
before LIMIT.
```